### PR TITLE
Fix matches types (#391)

### DIFF
--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -37,7 +37,7 @@ def get_wrapped(
     func: Callable[..., Any], responses: RequestsMock
 ) -> Callable[..., Any]: ...
 def json_params_matcher(
-    params: Optional[Dict[str, Dict[str, str]]]
+    params: Optional[Dict]
 ) -> Callable[..., Any]: ...
 def urlencoded_params_matcher(
     params: Optional[Dict[str, str]]


### PR DESCRIPTION
This method just takes in an optional dict. The implementation parses the json and compares the result. If we wanted to get really specific we could put in something more specific but the current type is just incorrect.